### PR TITLE
Fix MIME type for form body

### DIFF
--- a/lib/chaperon/action/http.ex
+++ b/lib/chaperon/action/http.ex
@@ -240,7 +240,7 @@ defmodule Chaperon.Action.HTTP do
 
   defp form_body(data) do
     {
-      %{"Content-Type" => "x-www-form-urlencoded"},
+      %{"Content-Type" => "application/x-www-form-urlencoded"},
       data |> URI.encode_query
     }
   end


### PR DESCRIPTION
Maybe we should add "; charset utf-8" to the end too? @bakkdoor 