### PR TITLE
Use case insensitive cookie header matching

### DIFF
--- a/lib/chaperon/session.ex
+++ b/lib/chaperon/session.ex
@@ -1285,14 +1285,8 @@ defmodule Chaperon.Session do
 
   defp response_cookies(response = %HTTPoison.Response{}) do
     response.headers
-    |> Enum.map(fn
-      {"Set-Cookie", cookie} ->
-        cookie
-
-      _ ->
-        nil
-    end)
-    |> Enum.reject(&is_nil/1)
+    |> Enum.filter(fn {key,_} -> String.match?(key, ~r/\Aset-cookie\z/i) end)
+    |> Enum.map(fn {_, value} -> value end)
   end
 
   @doc """


### PR DESCRIPTION
RTF 7230 explicitly states that HTTP header fields are case-insensitive. The old case-sensitive code failed for the falcon web server, which uses `set-cookie` instead of `Set-Cookie`.

https://tools.ietf.org/html/rfc7230#section-3.2