### PR TITLE
Follow HTTP standards setting request cookies

### DIFF
--- a/lib/chaperon/session.ex
+++ b/lib/chaperon/session.ex
@@ -1268,19 +1268,26 @@ defmodule Chaperon.Session do
     put_in(session.errors[action], error)
   end
 
+  defp store_cookies(session, []) do
+    session # do nothing
+  end
+
+  defp store_cookies(session, cookies) when is_list(cookies) do
+    cookies
+    |> Enum.join("; ")
+    |> put_in(session.cookies)
+  end
+
   @doc """
   Stores HTTP response cookies in `session` cookie store for further outgoing
   requests.
   """
   @spec store_cookies(Session.t(), HTTPoison.Response.t()) :: Session.t()
   def store_cookies(session, response = %HTTPoison.Response{}) do
-    case response_cookies(response) do
-      [] ->
-        session
-
-      cookies when is_list(cookies) ->
-        put_in(session.cookies, cookies)
-    end
+    response
+    |> response_cookies()
+    |> strip_cookie_attributes()
+    |> store_cookies(session)
   end
 
   defp response_cookies(response = %HTTPoison.Response{}) do
@@ -1293,6 +1300,14 @@ defmodule Chaperon.Session do
         nil
     end)
     |> Enum.reject(&is_nil/1)
+  end
+
+  # Strips attributes like Expires and HttpOnly from cookies. Only the name and
+  # value are allowed when sending cookies in requests.
+  defp strip_cookie_attributes(cookies) do
+    cookies |> Enum.map(fn value ->
+      String.replace(value, ~r/;.*$/, "", global: false)
+    end)
   end
 
   @doc """


### PR DESCRIPTION
Cookie headers in HTTP requests are only supposed to have a name and value ([RFC 6265](https://tools.ietf.org/html/rfc6265)). Chaperon was previously just echoing back the response cookies that came from the server, which included attributes like `Expires` and `HttpOnly`. When web servers parsed the `HTTP_COOKIE` header it would incorrectly create weird cookies like `HttpOnly` with a null value.

Setting multiple cookies was also broken: the hackney `cookie` option expects 1 cookie string joined with semicolons ([source](https://github.com/edgurgel/httpoison/issues/106)). Chaperon was previously joining them with newlines which would not get parsed correctly by the web server.