### PR TITLE
Add test for storing response cookies

### DIFF
--- a/lib/chaperon/action/http.ex
+++ b/lib/chaperon/action/http.ex
@@ -282,7 +282,7 @@ defimpl Chaperon.Actionable, for: Chaperon.Action.HTTP do
           {action.method, HTTP.metrics_url(action, session)},
           timestamp() - start
         )
-        |> store_cookies(response)
+        |> store_response_cookies(response)
         |> run_callback_if_defined(action, response)
         |> ok
 

--- a/lib/chaperon/session.ex
+++ b/lib/chaperon/session.ex
@@ -1301,10 +1301,7 @@ defmodule Chaperon.Session do
   end
 
   defp store_cookies(cookies, session) do
-    put_in(
-      session.cookies,
-      cookies |> Enum.join("; ")
-    )
+    put_in(session.cookies, [cookies |> Enum.join("; ")])
   end
 
   @doc """

--- a/lib/chaperon/session.ex
+++ b/lib/chaperon/session.ex
@@ -1300,7 +1300,7 @@ defmodule Chaperon.Session do
     session
   end
 
-  defp store_cookies(cookies, session) do
+  defp store_cookies(cookies, session) when is_list(cookies) do
     put_in(session.cookies, [cookies |> Enum.join("; ")])
   end
 

--- a/lib/chaperon/session.ex
+++ b/lib/chaperon/session.ex
@@ -1268,24 +1268,12 @@ defmodule Chaperon.Session do
     put_in(session.errors[action], error)
   end
 
-  def store_cookies(session, []) do
-    # do nothing
-    session
-  end
-
-  def store_cookies(session, cookies) when is_list(cookies) do
-    put_in(
-      session.cookies,
-      cookies |> Enum.join("; ")
-    )
-  end
-
   @doc """
   Stores HTTP response cookies in `session` cookie store for further outgoing
   requests.
   """
-  @spec store_cookies(Session.t(), HTTPoison.Response.t()) :: Session.t()
-  def store_cookies(session, response = %HTTPoison.Response{}) do
+  @spec store_response_cookies(Session.t(), HTTPoison.Response.t()) :: Session.t()
+  def store_response_cookies(session, response = %HTTPoison.Response{}) do
     response
     |> response_cookies()
     |> strip_cookie_attributes()
@@ -1305,6 +1293,18 @@ defmodule Chaperon.Session do
     |> Enum.map(fn value ->
       String.replace(value, ~r/;.*$/, "", global: false)
     end)
+  end
+
+  defp store_cookies([], session) do
+    # do nothing
+    session
+  end
+
+  defp store_cookies(cookies, session) do
+    put_in(
+      session.cookies,
+      cookies |> Enum.join("; ")
+    )
   end
 
   @doc """

--- a/test/chaperon/action/http_test.exs
+++ b/test/chaperon/action/http_test.exs
@@ -19,13 +19,13 @@ defmodule Chaperon.Action.HTTP.Test do
     action = %HTTP{}
 
     session = %Chaperon.Session{
-      cookies: ["cookie1", "cookie2"]
+      cookies: ["cookie1; cookie2"]
     }
 
     assert HTTP.options(action, session) == [
              params: %{},
              hackney: [
-               cookie: ["cookie1", "cookie2"],
+               cookie: ["cookie1; cookie2"],
                pool: :chaperon
              ]
            ]
@@ -51,14 +51,14 @@ defmodule Chaperon.Action.HTTP.Test do
     action = %HTTP{}
 
     session = %Chaperon.Session{
-      cookies: ["cookie1", "cookie2"],
+      cookies: ["cookie1; cookie2"],
       config: %{basic_auth: {"user1", "password1"}}
     }
 
     assert HTTP.options(action, session) == [
              params: %{},
              hackney: [
-               cookie: ["cookie1", "cookie2"],
+               cookie: ["cookie1; cookie2"],
                basic_auth: {"user1", "password1"},
                pool: :chaperon
              ]

--- a/test/chaperon/session_test.exs
+++ b/test/chaperon/session_test.exs
@@ -93,4 +93,17 @@ defmodule Chaperon.Session.Test do
     assert s5.assigned.ran_scenario == false
     assert s5.assigned.names == ["success_run"]
   end
+
+  test "store_response_cookies" do
+    response = %HTTPoison.Response{
+      headers: [
+        {"Set-Cookie", "cookie1=value1; Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly"},
+        {"set-cookie", "cookie2=value2"},
+        {"ETag", "ignored"}
+      ]
+    }
+    session = Chaperon.Session.store_response_cookies(%Chaperon.Session{}, response)
+
+    assert session.cookies == "cookie1=value1; cookie2=value2"
+  end
 end

--- a/test/chaperon/session_test.exs
+++ b/test/chaperon/session_test.exs
@@ -102,8 +102,9 @@ defmodule Chaperon.Session.Test do
         {"ETag", "ignored"}
       ]
     }
+
     session = Chaperon.Session.store_response_cookies(%Chaperon.Session{}, response)
 
-    assert session.cookies == "cookie1=value1; cookie2=value2"
+    assert session.cookies == ["cookie1=value1; cookie2=value2"]
   end
 end


### PR DESCRIPTION
Adds a test for the recent changes related to HTTP standards.

Fixes a bug that 1ba3758 introduced:

```ex
function Chaperon.Session.store_response_cookies/2 is undefined or private
```