### PR TITLE
Fix error logging when no sessions finish

### DIFF
--- a/lib/chaperon/load_test.ex
+++ b/lib/chaperon/load_test.ex
@@ -255,7 +255,7 @@ defmodule Chaperon.LoadTest do
   def merge_sessions(results = %Results{sessions: [], max_timeout: timeout}) do
     Logger.warn(
       "No scenario task finished in time (timeout = #{timeout}) for load_test: #{
-        results.load_test
+        inspect(results.load_test)
       }"
     )
 


### PR DESCRIPTION
Currently, when no sessions finish, this raises a `(Protocol.UndefinedError) protocol String.Chars not implemented` exception.