### PR TITLE
Add await interval

### DIFF
--- a/lib/chaperon/session.ex
+++ b/lib/chaperon/session.ex
@@ -17,7 +17,8 @@ defmodule Chaperon.Session do
             cookies: [],
             parent_id: nil,
             parent_pid: nil,
-            cancellation: nil
+            cancellation: nil,
+            timeout_at: nil
 
   @type t :: %Chaperon.Session{
           id: String.t(),
@@ -32,7 +33,8 @@ defmodule Chaperon.Session do
           cookies: [String.t()],
           parent_id: String.t() | nil,
           parent_pid: pid | nil,
-          cancellation: String.t() | nil
+          cancellation: String.t() | nil,
+          timeout_at: DateTime.t() | nil
         }
 
   @type metric :: {atom, any} | any
@@ -1176,15 +1178,12 @@ defmodule Chaperon.Session do
           nil | (Session.t(), any -> Session.t())
         ) :: Session.t()
   def await_signal_or_timeout(session, timeout, callback \\ nil) do
-    receive do
-      {:chaperon_signal, signal} ->
-        session
-        |> call_callback(callback, signal)
-    after
-      timeout ->
-        session
-        |> error({:timeout, :await_signal, timeout})
-    end
+    await_common(
+      session,
+      :__no_expected_signal__,
+      fn (session, signal) -> session |> call_callback(callback, signal) end,
+      timeout
+    )
   end
 
   @doc """
@@ -1204,16 +1203,12 @@ defmodule Chaperon.Session do
           any | (Session.t(), any -> Session.t())
         ) :: Session.t()
   def await_signal(session, callback) when is_function(callback) do
-    timeout = session |> timeout
-
-    receive do
-      {:chaperon_signal, signal} ->
-        callback.(session, signal)
-    after
-      timeout ->
-        session
-        |> error({:timeout, :await_signal, timeout})
-    end
+    await_common(
+      session,
+      :__no_expected_signal__,
+      callback,
+      session |> timeout
+    )
   end
 
   @doc """
@@ -1226,16 +1221,12 @@ defmodule Chaperon.Session do
       |> get("/search", params: [query: "Got load test?"])
   """
   def await_signal(session, expected_signal) do
-    timeout = session |> timeout
-
-    receive do
-      {:chaperon_signal, ^expected_signal} ->
-        session
-    after
-      timeout ->
-        session
-        |> error({:timeout, :await_signal, timeout})
-    end
+    await_common(
+      session,
+      expected_signal,
+      fn (session, _) -> session end,
+      session |> timeout
+    )
   end
 
   @doc """
@@ -1249,15 +1240,69 @@ defmodule Chaperon.Session do
   """
   @spec await_signal(Session.t(), any, non_neg_integer) :: Session.t()
   def await_signal(session, expected_signal, timeout) do
+    await_common(
+      session,
+      expected_signal,
+      fn (session, _) -> session end,
+      timeout
+    )
+  end
+
+  defp await_common(session, expected_signal, callback, timeout) do
+    session =
+      %{session | timeout_at: get_timeout_at(timeout)}
+
+    msg_ref = make_ref()
+
+    tref = case session.config[:interval] do
+      {interval, fun} ->
+        :timer.send_interval(interval, {:chaperon_interval, msg_ref, fun})
+      nil ->
+        nil
+    end
+
+    session = do_await_common(session, expected_signal, callback, timeout, msg_ref)
+
+    tref && :timer.cancel(tref)
+
+    session
+  end
+
+  defp get_timeout_at(:infinity), do: :infinity
+  defp get_timeout_at(timeout), do:
+    DateTime.utc_now() |> DateTime.add(timeout, :millisecond)
+
+  defp do_await_common(
+    session,
+    expected_signal,
+    callback,
+    timeout,
+    msg_ref
+    ) do
+
+    remaining_time = max(0, get_remaining_time(session.timeout_at))
+
     receive do
       {:chaperon_signal, ^expected_signal} ->
+        callback.(session, expected_signal)
+
+      {:chaperon_signal, signal}
+      when expected_signal == :__no_expected_signal__ ->
+        callback.(session, signal)
+
+      {:chaperon_interval, ^msg_ref, fun} ->
         session
-    after
-      timeout ->
-        session
-        |> error({:timeout, :await_signal, timeout})
+        |> fun.()
+        |> do_await_common(expected_signal, callback, timeout, msg_ref)
+
+    after remaining_time ->
+        session |> error({:timeout, :await_signal, timeout})
     end
   end
+
+  defp get_remaining_time(:infinity), do: :infinity
+  defp get_remaining_time(timeout_at), do:
+    DateTime.diff(timeout_at, DateTime.utc_now(), :millisecond)
 
   @doc """
   Removes a `Task` with a given `task_name` from `session`.


### PR DESCRIPTION
I'm using Chaperon to do some load testing on our Absinthe (https://github.com/absinthe-graphql/absinthe) GraphQL server. The issue I've run into is that, when running with a phoenix websocket, I need to send a heartbeat every 30 seconds or so while idling or the server drops the connection. Unfortunately that doesn't fit well with the model used by chaperon where stuff happens basically in a strict order, and so calling the blocking `await` or `await_signal` functions doesn't allow for a purely time-based number of heatbeat send/receives during the waiting.

This change attempts to provide a generic method by which this can be done, adding an `interval` config option of the form `{period, function}`. The effect is that during any `await` operation, `function` is called once per `period` milliseconds. In this way we can inject a `ws_send`/`ws_recv` pair to handle the heartbeat and response while still waiting.

I've implemented it for both `await_signal` and `await` (task) however there's currently a bit of a difference: The first variant uses the main worker process and a single session, while the latter spawns off a separate worker process and merges the session back at the end of the wait period. I'm not especially happy with that discrepancy, so I'm more than happy to take feedback on that (or anything else) to make it better.

As part of this I also wrote a bunch of tests for the existing `await` functionality to make sure I didn't break it too badly.