### PR TITLE
Use "extra_applications" instead of "applications"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,17 +39,9 @@ defmodule Chaperon.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [
+      extra_applications: [
         :logger,
-        :httpoison,
-        :uuid,
-        :poison,
-        :histogrex,
-        :websockex,
-        :ssl,
-        :crypto,
-        :instream,
-        :deep_merge
+        :inets
       ],
       mod: {Chaperon, []}
     ]


### PR DESCRIPTION
`e_q` was missing from the `applications` list, meaning a release built with chaperon would also be missing it. I've updated `mix.exs` to use the newer `extra_applications` tag which both fixes the issue and means one less thing to maintain when deps are added.