### PR TITLE
Fix deprecated to_unix call

### DIFF
--- a/lib/chaperon/action/loop.ex
+++ b/lib/chaperon/action/loop.ex
@@ -23,8 +23,8 @@ defimpl Chaperon.Actionable, for: Chaperon.Action.Loop do
   end
 
   def run(loop = %{action: a, duration: d}, session) do
-    now = DateTime.utc_now() |> DateTime.to_unix(:milliseconds)
-    s = loop.started |> DateTime.to_unix(:milliseconds)
+    now = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+    s = loop.started |> DateTime.to_unix(:millisecond)
 
     if now - s > d do
       {:ok, _, session} = loop |> abort(session)


### PR DESCRIPTION
:milliseconds -> :millisecond. All calls are singular now.