### PR TITLE
Allow Hackney to be configured with insecure option

### DIFF
--- a/lib/chaperon/action/http.ex
+++ b/lib/chaperon/action/http.ex
@@ -207,7 +207,8 @@ defmodule Chaperon.Action.HTTP do
     opts = [
       cookie: session.cookies,
       basic_auth: session.config[:basic_auth],
-      pool: :chaperon
+      pool: :chaperon,
+      insecure: session.config[:insecure]
     ]
 
     opts


### PR DESCRIPTION
This is useful for environments using self-signed certificates.